### PR TITLE
fix: building examples need config extension

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,15 @@ module.exports = {
               ]
             }
           },
-          "ts-loader"
+          {
+            loader: "ts-loader",
+            options: {
+              compilerOptions: {
+                rootDir: null,
+                rootDirs: ["src", "examples/src"],
+              },
+            },
+          },
         ]
       },
       {


### PR DESCRIPTION
Examples wouldn't build since `examples/src` isn't in `rootDir`. By `null`ing `rootDir` and setting `rootDirs` in `ts-loader`'s `compilerOptions`, everything works.